### PR TITLE
User creation for all images

### DIFF
--- a/PHP_5_6/Dockerfile
+++ b/PHP_5_6/Dockerfile
@@ -1,5 +1,12 @@
 FROM debian:jessie
 
+ARG USER_PUID=1000
+ARG USER_PGID=1000
+ARG USER_NAME=php
+
+RUN groupadd --gid $USER_PGID $USER_NAME \
+	&& useradd --uid $USER_PUID --gid $USER_NAME -m $USER_NAME
+
 ENV PHPIZE_DEPS \
 	autoconf \
 	dpkg-dev \
@@ -190,6 +197,8 @@ RUN cd /usr/src/php/scripts/dev \
 	&& rm generate-phpt.phar \
 	&& php -d phar.readonly=0 generate-phpt/gtPackage.php \
 	&& cd /
+
+RUN chown -R $USER_NAME.$USER_NAME /usr/src/
 
 WORKDIR /usr/src/php/
 CMD ["/bin/bash"]

--- a/PHP_7_0/Dockerfile
+++ b/PHP_7_0/Dockerfile
@@ -1,5 +1,12 @@
 FROM debian:jessie
 
+ARG USER_PUID=1000
+ARG USER_PGID=1000
+ARG USER_NAME=php
+
+RUN groupadd --gid $USER_PGID $USER_NAME \
+	&& useradd --uid $USER_PUID --gid $USER_NAME -m $USER_NAME
+
 ENV PHPIZE_DEPS \
 	autoconf \
 	dpkg-dev \
@@ -188,6 +195,8 @@ RUN cd /usr/src/php/scripts/dev \
 	&& rm generate-phpt.phar \
 	&& php -d phar.readonly=0 generate-phpt/gtPackage.php \
 	&& cd /
+
+RUN chown -R $USER_NAME.$USER_NAME /usr/src/
 
 WORKDIR /usr/src/php/
 CMD ["/bin/bash"]

--- a/PHP_7_1/Dockerfile
+++ b/PHP_7_1/Dockerfile
@@ -1,5 +1,12 @@
 FROM debian:jessie
 
+ARG USER_PUID=1000
+ARG USER_PGID=1000
+ARG USER_NAME=php
+
+RUN groupadd --gid $USER_PGID $USER_NAME \
+	&& useradd --uid $USER_PUID --gid $USER_NAME -m $USER_NAME
+
 ENV PHPIZE_DEPS \
 	autoconf \
 	dpkg-dev \
@@ -188,6 +195,8 @@ RUN cd /usr/src/php/scripts/dev \
 	&& rm generate-phpt.phar \
 	&& php -d phar.readonly=0 generate-phpt/gtPackage.php \
 	&& cd /
+
+RUN chown -R $USER_NAME.$USER_NAME /usr/src/
 
 WORKDIR /usr/src/php/
 CMD ["/bin/bash"]

--- a/PHP_7_2/Dockerfile
+++ b/PHP_7_2/Dockerfile
@@ -1,5 +1,12 @@
 FROM debian:jessie
 
+ARG USER_PUID=1000
+ARG USER_PGID=1000
+ARG USER_NAME=php
+
+RUN groupadd --gid $USER_PGID $USER_NAME \
+    && useradd --uid $USER_PUID --gid $USER_NAME -m $USER_NAME
+
 ENV PHPIZE_DEPS \
     autoconf \
     dpkg-dev \
@@ -188,6 +195,8 @@ RUN cd /usr/src/php/scripts/dev \
     && rm generate-phpt.phar \
     && php -d phar.readonly=0 generate-phpt/gtPackage.php \
     && cd /
+
+RUN chown -R $USER_NAME.$USER_NAME /usr/src/
 
 WORKDIR /usr/src/php/
 CMD ["/bin/bash"]

--- a/PHP_HEAD/Dockerfile
+++ b/PHP_HEAD/Dockerfile
@@ -1,5 +1,12 @@
 FROM debian:jessie
 
+ARG USER_PUID=1000
+ARG USER_PGID=1000
+ARG USER_NAME=php
+
+RUN groupadd --gid $USER_PGID $USER_NAME \
+    && useradd --uid $USER_PUID --gid $USER_NAME -m $USER_NAME
+
 ENV PHPIZE_DEPS \
     autoconf \
     dpkg-dev \
@@ -213,6 +220,8 @@ RUN cd /usr/src/php/scripts/dev \
     && rm generate-phpt.phar \
     && php -d phar.readonly=0 generate-phpt/gtPackage.php \
     && cd /
+
+RUN chown -R $USER_NAME.$USER_NAME /usr/src/
 
 WORKDIR /usr/src/php/
 CMD ["/bin/bash"]


### PR DESCRIPTION
When executing the following command, the file that was generated was being the root user.
```
docker run --rm -i -t -w /usr/src/phpt -v $PWD:/usr/src/phpt phptestfestbrasil/phptt:7.1 \
        php /usr/src/php/scripts/dev/generate-phpt.phar -f in_array -b
```
With the creation of the user in the image build, we can now execute the following command passing the user as parameter.

```
docker run -u php --rm -i -t -w /usr/src/phpt -v $PWD:/usr/src/phpt phptestfestbrasil/phptt:7.1 \
        php /usr/src/php/scripts/dev/generate-phpt.phar -f in_array -b
```