### PR TITLE
Added qq option to unzip

### DIFF
--- a/PHP_HEAD/docker-php-source
+++ b/PHP_HEAD/docker-php-source
@@ -18,7 +18,7 @@ case "$1" in
 	extract)
 		mkdir -p "$dir"
 		if [ -f "/usr/src/php-src-master.zip" ]; then
-            unzip /usr/src/php-src-master.zip -d "/tmp" && mv /tmp/php-src-master/* "$dir"
+            unzip -qq /usr/src/php-src-master.zip -d "/tmp" && mv /tmp/php-src-master/* "$dir"
 		elif [ -f "/usr/src/php-src-PHP-7.2.zip" ]; then
 			unzip /usr/src/php-src-PHP-7.2.zip -d "/tmp" && mv /tmp/php-src-PHP-7.2/* "$dir"
 		elif [ -f "/usr/src/php-src-PHP-7.1.zip" ]; then


### PR DESCRIPTION
Added qq option to unzip to avoid build error:
  "The job exceeded the maximum log length, and has been terminated."